### PR TITLE
local discovery fix

### DIFF
--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -198,8 +198,7 @@ impl Platform {
                     tracing::trace!(class="Platform", "Local discovery reply send success");
                 },
                 Err(e) => {
-                    return platform_error!(
-                        format!("Json request not correctly formatted"), None)
+                    tracing::trace!(class="Platform", "Json request not correctly formatted");
                 }
             }
         }


### PR DESCRIPTION
 if bad format request send didn't kill the local discovery service anymore (just print a log message)