### PR TITLE
73 sometimes the command is not received correctly

### DIFF
--- a/src/builtin_devices/panduza/voxpower_inhibiter/itf_voxpower_inhibiter.rs
+++ b/src/builtin_devices/panduza/voxpower_inhibiter/itf_voxpower_inhibiter.rs
@@ -63,9 +63,10 @@ impl relay::RelayActions for VoxpowerInhibiterActions {
                 println!("nb of bytes: {:?}", nb_of_bytes);
                 let response_bytes = &response_buf[0..nb_of_bytes];
                 let response_string = String::from_utf8(response_bytes.to_vec()).unwrap();
-                let state = response_string.split("\n").next().unwrap();
-                println!("VoxpowerInhibiterActions - channel {} state: {:?}", self.id, state);
-                if state == "H" {
+                println!("{:?}", response_string);
+                // let state = response_string.split("\n").next().unwrap();
+                println!("VoxpowerInhibiterActions - channel {} state: {:?}", self.id, response_string);
+                if response_string == "H" {
                     self.state_open = true;
                 } else {
                     self.state_open = false;
@@ -89,6 +90,7 @@ impl relay::RelayActions for VoxpowerInhibiterActions {
             format!("E{}\n", self.id)
         };
 
+        println!("{}", command);
         let _result = self.connector_tty.write(
             command.as_bytes(),
             self.time_lock_duration

--- a/src/builtin_devices/panduza/voxpower_inhibiter/itf_voxpower_inhibiter.rs
+++ b/src/builtin_devices/panduza/voxpower_inhibiter/itf_voxpower_inhibiter.rs
@@ -63,8 +63,6 @@ impl relay::RelayActions for VoxpowerInhibiterActions {
                 println!("nb of bytes: {:?}", nb_of_bytes);
                 let response_bytes = &response_buf[0..nb_of_bytes];
                 let response_string = String::from_utf8(response_bytes.to_vec()).unwrap();
-                println!("{:?}", response_string);
-                // let state = response_string.split("\n").next().unwrap();
                 println!("VoxpowerInhibiterActions - channel {} state: {:?}", self.id, response_string);
                 if response_string == "H" {
                     self.state_open = true;
@@ -90,7 +88,6 @@ impl relay::RelayActions for VoxpowerInhibiterActions {
             format!("E{}\n", self.id)
         };
 
-        println!("{}", command);
         let _result = self.connector_tty.write(
             command.as_bytes(),
             self.time_lock_duration


### PR DESCRIPTION
When the arduino was sending the response with \n the message was sometimes split and it broke the interfaces so the \n was removed